### PR TITLE
Fix paginations in DM channels

### DIFF
--- a/src/main/java/com/github/ygimenez/listener/MessageHandler.java
+++ b/src/main/java/com/github/ygimenez/listener/MessageHandler.java
@@ -66,7 +66,10 @@ public class MessageHandler extends ListenerAdapter {
 		evt.retrieveUser().submit().thenAccept(u -> {
 			if (u.isBot()) return;
 
-			if ((Pages.isActivated() && Pages.getPaginator() == null) || (Pages.isActivated() && Pages.getPaginator().isRemoveOnReact())) {
+			boolean removeOnReact =
+					(Pages.isActivated() && Pages.getPaginator() == null) || (Pages.isActivated() && Pages.getPaginator().isRemoveOnReact());
+
+			if (evt.isFromGuild() && removeOnReact) {
 				evt.getPrivateChannel().retrieveMessageById(evt.getMessageId()).submit().thenAccept(msg -> {
 					switch (evt.getChannelType()) {
 						case TEXT:

--- a/src/main/java/com/github/ygimenez/method/Pages.java
+++ b/src/main/java/com/github/ygimenez/method/Pages.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -299,7 +300,30 @@ public class Pages {
 			};
 
 			{
-				timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				setTimeout();
+			}
+
+			private void setTimeout() {
+				try {
+					timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				} catch (InsufficientPermissionException | IllegalStateException e) {
+					timeout = msg.getChannel()
+							.retrieveMessageById(msg.getId())
+							.submitAfter(time, unit)
+							.thenCompose(message -> {
+								CompletableFuture<?>[] removeReaction = new CompletableFuture[message.getReactions().size()];
+
+								for (int i = 0; i < message.getReactions().size(); i++) {
+									MessageReaction r = message.getReactions().get(i);
+
+									if (!r.isSelf()) continue;
+
+									removeReaction[i] = r.removeReaction().submit();
+								}
+
+								return CompletableFuture.allOf(removeReaction).thenAccept(success);
+							});
+				}
 			}
 
 			@Override
@@ -487,7 +511,30 @@ public class Pages {
 			};
 
 			{
-				timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				setTimeout();
+			}
+
+			private void setTimeout() {
+				try {
+					timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				} catch (InsufficientPermissionException | IllegalStateException e) {
+					timeout = msg.getChannel()
+							.retrieveMessageById(msg.getId())
+							.submitAfter(time, unit)
+							.thenCompose(message -> {
+								CompletableFuture<?>[] removeReaction = new CompletableFuture[message.getReactions().size()];
+
+								for (int i = 0; i < message.getReactions().size(); i++) {
+									MessageReaction r = message.getReactions().get(i);
+
+									if (!r.isSelf()) continue;
+
+									removeReaction[i] = r.removeReaction().submit();
+								}
+
+								return CompletableFuture.allOf(removeReaction).thenAccept(success);
+							});
+				}
 			}
 
 			@Override
@@ -535,10 +582,7 @@ public class Pages {
 							timeout.cancel(true);
 							timeout = null;
 						}
-						try {
-							timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
-						} catch (InsufficientPermissionException ignore) {
-						}
+						setTimeout();
 
 						if (event.isFromGuild() && (paginator == null || paginator.isRemoveOnReact())) {
 							try {
@@ -692,7 +736,30 @@ public class Pages {
 			};
 
 			{
-				timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				setTimeout();
+			}
+
+			private void setTimeout() {
+				try {
+					timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				} catch (InsufficientPermissionException | IllegalStateException e) {
+					timeout = msg.getChannel()
+							.retrieveMessageById(msg.getId())
+							.submitAfter(time, unit)
+							.thenCompose(message -> {
+								CompletableFuture<?>[] removeReaction = new CompletableFuture[message.getReactions().size()];
+
+								for (int i = 0; i < message.getReactions().size(); i++) {
+									MessageReaction r = message.getReactions().get(i);
+
+									if (!r.isSelf()) continue;
+
+									removeReaction[i] = r.removeReaction().submit();
+								}
+
+								return CompletableFuture.allOf(removeReaction).thenAccept(success);
+							});
+				}
 			}
 
 			@Override
@@ -915,7 +982,30 @@ public class Pages {
 			};
 
 			{
-				timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				setTimeout();
+			}
+
+			private void setTimeout() {
+				try {
+					timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				} catch (InsufficientPermissionException | IllegalStateException e) {
+					timeout = msg.getChannel()
+							.retrieveMessageById(msg.getId())
+							.submitAfter(time, unit)
+							.thenCompose(message -> {
+								CompletableFuture<?>[] removeReaction = new CompletableFuture[message.getReactions().size()];
+
+								for (int i = 0; i < message.getReactions().size(); i++) {
+									MessageReaction r = message.getReactions().get(i);
+
+									if (!r.isSelf()) continue;
+
+									removeReaction[i] = r.removeReaction().submit();
+								}
+
+								return CompletableFuture.allOf(removeReaction).thenAccept(success);
+							});
+				}
 			}
 
 			@Override
@@ -977,10 +1067,7 @@ public class Pages {
 							timeout.cancel(true);
 							timeout = null;
 						}
-						try {
-							timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
-						} catch (InsufficientPermissionException ignore) {
-						}
+						setTimeout();
 
 						if (event.isFromGuild() && (paginator == null || paginator.isRemoveOnReact())) {
 							try {
@@ -1135,7 +1222,30 @@ public class Pages {
 			};
 
 			{
-				timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				setTimeout();
+			}
+
+			private void setTimeout() {
+				try {
+					timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				} catch (InsufficientPermissionException | IllegalStateException e) {
+					timeout = msg.getChannel()
+							.retrieveMessageById(msg.getId())
+							.submitAfter(time, unit)
+							.thenCompose(message -> {
+								CompletableFuture<?>[] removeReaction = new CompletableFuture[message.getReactions().size()];
+
+								for (int i = 0; i < message.getReactions().size(); i++) {
+									MessageReaction r = message.getReactions().get(i);
+
+									if (!r.isSelf()) continue;
+
+									removeReaction[i] = r.removeReaction().submit();
+								}
+
+								return CompletableFuture.allOf(removeReaction).thenAccept(success);
+							});
+				}
 			}
 
 			@Override
@@ -1359,7 +1469,30 @@ public class Pages {
 			};
 
 			{
-				timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				setTimeout();
+			}
+
+			private void setTimeout() {
+				try {
+					timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				} catch (InsufficientPermissionException | IllegalStateException e) {
+					timeout = msg.getChannel()
+							.retrieveMessageById(msg.getId())
+							.submitAfter(time, unit)
+							.thenCompose(message -> {
+								CompletableFuture<?>[] removeReaction = new CompletableFuture[message.getReactions().size()];
+
+								for (int i = 0; i < message.getReactions().size(); i++) {
+									MessageReaction r = message.getReactions().get(i);
+
+									if (!r.isSelf()) continue;
+
+									removeReaction[i] = r.removeReaction().submit();
+								}
+
+								return CompletableFuture.allOf(removeReaction).thenAccept(success);
+							});
+				}
 			}
 
 			@Override
@@ -1421,10 +1554,7 @@ public class Pages {
 							timeout.cancel(true);
 							timeout = null;
 						}
-						try {
-							timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
-						} catch (InsufficientPermissionException ignore) {
-						}
+						setTimeout();
 
 						if (event.isFromGuild() && (paginator == null || paginator.isRemoveOnReact())) {
 							try {
@@ -1605,7 +1735,30 @@ public class Pages {
 			};
 
 			{
-				timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				setTimeout();
+			}
+
+			private void setTimeout() {
+				try {
+					timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				} catch (InsufficientPermissionException | IllegalStateException e) {
+					timeout = msg.getChannel()
+							.retrieveMessageById(msg.getId())
+							.submitAfter(time, unit)
+							.thenCompose(message -> {
+								CompletableFuture<?>[] removeReaction = new CompletableFuture[message.getReactions().size()];
+
+								for (int i = 0; i < message.getReactions().size(); i++) {
+									MessageReaction r = message.getReactions().get(i);
+
+									if (!r.isSelf()) continue;
+
+									removeReaction[i] = r.removeReaction().submit();
+								}
+
+								return CompletableFuture.allOf(removeReaction).thenAccept(success);
+							});
+				}
 			}
 
 			@Override
@@ -1681,10 +1834,7 @@ public class Pages {
 							timeout.cancel(true);
 							timeout = null;
 						}
-						try {
-							timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
-						} catch (InsufficientPermissionException ignore) {
-						}
+						setTimeout();
 
 						if (event.isFromGuild() && (paginator == null || paginator.isRemoveOnReact())) {
 							try {
@@ -1817,7 +1967,30 @@ public class Pages {
 			};
 
 			{
-				timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				setTimeout();
+			}
+
+			private void setTimeout() {
+				try {
+					timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				} catch (InsufficientPermissionException | IllegalStateException e) {
+					timeout = msg.getChannel()
+							.retrieveMessageById(msg.getId())
+							.submitAfter(time, unit)
+							.thenCompose(message -> {
+								CompletableFuture<?>[] removeReaction = new CompletableFuture[message.getReactions().size()];
+
+								for (int i = 0; i < message.getReactions().size(); i++) {
+									MessageReaction r = message.getReactions().get(i);
+
+									if (!r.isSelf()) continue;
+
+									removeReaction[i] = r.removeReaction().submit();
+								}
+
+								return CompletableFuture.allOf(removeReaction).thenAccept(success);
+							});
+				}
 			}
 
 			@Override
@@ -1995,7 +2168,30 @@ public class Pages {
 			};
 
 			{
-				timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				setTimeout();
+			}
+
+			private void setTimeout() {
+				try {
+					timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				} catch (InsufficientPermissionException | IllegalStateException e) {
+					timeout = msg.getChannel()
+							.retrieveMessageById(msg.getId())
+							.submitAfter(time, unit)
+							.thenCompose(message -> {
+								CompletableFuture<?>[] removeReaction = new CompletableFuture[message.getReactions().size()];
+
+								for (int i = 0; i < message.getReactions().size(); i++) {
+									MessageReaction r = message.getReactions().get(i);
+
+									if (!r.isSelf()) continue;
+
+									removeReaction[i] = r.removeReaction().submit();
+								}
+
+								return CompletableFuture.allOf(removeReaction).thenAccept(success);
+							});
+				}
 			}
 
 			@Override
@@ -2032,10 +2228,7 @@ public class Pages {
 							timeout.cancel(true);
 							timeout = null;
 						}
-						try {
-							timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
-						} catch (InsufficientPermissionException ignore) {
-						}
+						setTimeout();
 
 						currCat = updateCategory(event.getReactionEmote().getName(), msg, pg);
 						if (event.isFromGuild() && (paginator == null || paginator.isRemoveOnReact())) {
@@ -2177,7 +2370,30 @@ public class Pages {
 			};
 
 			{
-				timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				setTimeout();
+			}
+
+			private void setTimeout() {
+				try {
+					timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				} catch (InsufficientPermissionException | IllegalStateException e) {
+					timeout = msg.getChannel()
+							.retrieveMessageById(msg.getId())
+							.submitAfter(time, unit)
+							.thenCompose(message -> {
+								CompletableFuture<?>[] removeReaction = new CompletableFuture[message.getReactions().size()];
+
+								for (int i = 0; i < message.getReactions().size(); i++) {
+									MessageReaction r = message.getReactions().get(i);
+
+									if (!r.isSelf()) continue;
+
+									removeReaction[i] = r.removeReaction().submit();
+								}
+
+								return CompletableFuture.allOf(removeReaction).thenAccept(success);
+							});
+				}
 			}
 
 			@Override
@@ -2373,7 +2589,30 @@ public class Pages {
 			};
 
 			{
-				timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				setTimeout();
+			}
+
+			private void setTimeout() {
+				try {
+					timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				} catch (InsufficientPermissionException | IllegalStateException e) {
+					timeout = msg.getChannel()
+							.retrieveMessageById(msg.getId())
+							.submitAfter(time, unit)
+							.thenCompose(message -> {
+								CompletableFuture<?>[] removeReaction = new CompletableFuture[message.getReactions().size()];
+
+								for (int i = 0; i < message.getReactions().size(); i++) {
+									MessageReaction r = message.getReactions().get(i);
+
+									if (!r.isSelf()) continue;
+
+									removeReaction[i] = r.removeReaction().submit();
+								}
+
+								return CompletableFuture.allOf(removeReaction).thenAccept(success);
+							});
+				}
 			}
 
 			@Override
@@ -2417,10 +2656,7 @@ public class Pages {
 							timeout.cancel(true);
 							timeout = null;
 						}
-						try {
-							timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
-						} catch (InsufficientPermissionException ignore) {
-						}
+						setTimeout();
 
 						if (event.isFromGuild() && (paginator == null || paginator.isRemoveOnReact())) {
 							try {
@@ -2572,7 +2808,30 @@ public class Pages {
 			};
 
 			{
-				timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				setTimeout();
+			}
+
+			private void setTimeout() {
+				try {
+					timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
+				} catch (InsufficientPermissionException | IllegalStateException e) {
+					timeout = msg.getChannel()
+							.retrieveMessageById(msg.getId())
+							.submitAfter(time, unit)
+							.thenCompose(message -> {
+								CompletableFuture<?>[] removeReaction = new CompletableFuture[message.getReactions().size()];
+
+								for (int i = 0; i < message.getReactions().size(); i++) {
+									MessageReaction r = message.getReactions().get(i);
+
+									if (!r.isSelf()) continue;
+
+									removeReaction[i] = r.removeReaction().submit();
+								}
+
+								return CompletableFuture.allOf(removeReaction).thenAccept(success);
+							});
+				}
 			}
 
 			@Override
@@ -2616,10 +2875,7 @@ public class Pages {
 							timeout.cancel(true);
 							timeout = null;
 						}
-						try {
-							timeout = msg.clearReactions().submitAfter(time, unit).thenAccept(success);
-						} catch (InsufficientPermissionException ignore) {
-						}
+						setTimeout();
 
 						if (event.isFromGuild() && (paginator == null || paginator.isRemoveOnReact())) {
 							try {


### PR DESCRIPTION
After the release of 2.1.1 I was still encountering some issues using the library in a DM.

1. As described in #9, I was experiencing the following error when a page is initialised for a message in a DM while using the timeout feature. 2.1.1 did not seem to fix this (as seen by the version in the jar name):
```
java.lang.IllegalStateException: Cannot clear reactions from a message in a Group or PrivateChannel.
	at net.dv8tion.jda.internal.entities.ReceivedMessage.clearReactions(ReceivedMessage.java:175) ~[JDA-4.2.0_225.jar:4.2.0_225]
	at com.github.ygimenez.method.Pages$4.<init>(Pages.java:490) ~[Pagination-Utils-2.1.1.jar:na]
	at com.github.ygimenez.method.Pages.paginate(Pages.java:477) ~[Pagination-Utils-2.1.1.jar:na]
```
2. Using the non-timeout `paginate` methods, I was able to get around this issue but if I had set `.shouldRemoveOnReact(true)` for the paginator builder then switching pages would only work when a user removed their reaction and then re-added their reaction. 

In this PR I believe that I have fixed both of these issues. One thing I want to point out is that, in the `Pages.java` class, I noticed there were not many methods to cut down on duplicated code in the consumers. In order to maintain the style of the code I decided to create `setTimeout()` methods inside each consumer instead of making one method in the class and referring to that for all the consumers. If you would like me to change to using the latter style (one method that all the consumers use) I'm happy to change over to that.