### PR TITLE
Gradle install instructions cleared up.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ This library is available for manual installation and through Jitpack:
 Gradle:
 
 ```gradle
+repositories {
+    maven { url 'https://jitpack.io' }
+}
 dependencies {
     implementation group: 'com.github.ygimenez', name: 'Pagination-Utils', version: 'VERSION'
 }


### PR DESCRIPTION
Added the necessary Jitpack repository URL for build.gradle. Otherwise only having the dependencies section would not allow for the Gradle project to build properly.

This is needed, README.md was not clear about it: 
maven { url 'https://jitpack.io' }